### PR TITLE
Upgraded crowd library version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 
         <!-- Dependencies -->
         <spring.boot.version>2.1.4.RELEASE</spring.boot.version>
-        <spring.security.crowd.version>3.4.3</spring.security.crowd.version>
+        <spring.security.crowd.version>3.7.0</spring.security.crowd.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Was breaking OWASP dependency check due to CVE-2019-15005.